### PR TITLE
Fetch XSL Stylesheet, Move it to the Public Folder, Replace Each Sitemap's Stylesheet href

### DIFF
--- a/parse-sitemap.js
+++ b/parse-sitemap.js
@@ -39,4 +39,15 @@ async function extractUrls(xml, cliFlags) {
   return urls;
 }
 
+async function extractXslUrl(xml) {
+  const $ = cheerio.load(xml, { xmlMode: true });
+  var preamble = $.root()[0].children.filter(x => x.type === "directive");
+  var xslDirective = preamble.find(
+    directive => directive.name === "?xml-stylesheet"
+  );
+  var xslUrl = xslDirective.data.match('href="//(.*?)"');
+  return xslUrl[1];
+}
+
 exports.extractUrls = extractUrls;
+exports.extractXslUrl = extractXslUrl;


### PR DESCRIPTION
### Description
This pull request addresses the following issue: https://github.com/audal/gatsby-plugin-yoast-sitemap/issues/1

Essentially, the plugin in its current state is not styling sitemaps like Yoast does for a pure WordPress site. This pull request fetches the main stylesheet, moves it to the public folder, and updates all the sitemap files to reference the relocated stylesheet.