### PR TITLE
Added replace functions for baseUrl

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -29,6 +29,8 @@ exports.createPages = async ({ actions, graphql }, options) => {
 
   gatsbyUrl = gatsbyUrl.replace("https://", "");
   gatsbyUrl = gatsbyUrl.replace("http://", "");
+  baseUrl = baseUrl.replace("https://", "");
+  baseUrl = baseUrl.replace("http://", "");
 
   let siteMapIndex = await axios.get(
     `https://${withoutTrailingSlash(baseUrl)}/sitemap_index.xml`,


### PR DESCRIPTION
Prevents baseUrl from causing error on build if the variable contains http/https prefix.